### PR TITLE
fix(docker): strip the image down to 52 CVEs, none critical or high

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,17 @@ docker run -d \
 
 Arayüz: **http://\<sunucu-ip\>:5883**
 
+### ⚠️ İmajda `apt` yok
+
+İmaj `perl-base`, `debconf`, `gosu`, `curl`, `pip` ve `setuptools` olmadan
+gelir: hiçbiri çalışma anında kullanılmıyordu ama aralarında Debian'ın düzeltme
+yayınlamadığı 2 CRITICAL ve 18 HIGH dahil 70 CVE taşıyorlardı. Bunun bedeli
+`docker exec mynes apt-get install ...` komutunun çalışmaması.
+
+Konteyner içine ek bir araç gerekiyorsa `deploy/Dockerfile`'daki `apt-get
+install` satırına ekleyip yeniden derleyin — çalışan konteynere sonradan paket
+kurmak zaten kaybolan bir değişiklikti.
+
 ### ⚠️ Neden host ağı ve NET_RAW?
 
 MyNeS ham ARP paketleri gönderir ve mDNS/SSDP multicast dinler. İkisi de host ağ

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -16,10 +16,19 @@ LABEL org.opencontainers.image.documentation="https://github.com/fxerkan/my_netw
 LABEL org.opencontainers.image.created="${BUILD_DATE}"
 LABEL org.opencontainers.image.version="${VERSION}"
 
+# perl-base carries 2 CRITICAL + 2 HIGH CVEs that Debian has no fix for, and
+# nothing here runs perl - nmap's NSE is Lua. Its only dependant is debconf,
+# which only matters to apt, and apt is finished by the end of this layer.
+# --force-depends leaves debconf installed but broken; that is the whole cost:
+# the image can no longer apt-get install. See README, "İmajda apt yok".
+# gosu is gone too: its Go stdlib carried 39 CVEs and setpriv (util-linux, part
+# of the base image) does the same drop-to-user job. See entrypoint.sh.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    nmap iputils-ping net-tools iproute2 curl avahi-utils \
-    libcap2-bin gosu \
-    && rm -rf /var/lib/apt/lists/*
+    nmap iputils-ping net-tools iproute2 avahi-utils \
+    libcap2-bin \
+    && rm -rf /var/lib/apt/lists/* \
+    && dpkg --force-remove-essential --force-depends --purge perl-base \
+    && rm -rf /usr/share/perl /usr/share/perl5 /usr/bin/perl*
 
 WORKDIR /app
 
@@ -30,7 +39,10 @@ COPY pyproject.toml README.md LICENSE ./
 COPY mynes ./mynes
 COPY config ./config
 
-RUN pip install --no-cache-dir --no-deps -e . && mkdir -p /app/data
+# Not editable: an editable install needs pip's machinery to stay behind, and
+# pip/setuptools/wheel are 5 more CVEs for something nothing runs at runtime.
+RUN pip install --no-cache-dir --no-deps . && mkdir -p /app/data \
+    && pip uninstall -y pip setuptools wheel
 
 ENV PYTHONUNBUFFERED=1 \
     MYNES_HOME=/app \
@@ -50,8 +62,12 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 5883
 
+# python, not curl: curl dragged in libcurl/openldap/krb5/gnutls and 15 CVEs for
+# one HTTP GET. http.client rather than urllib because urlopen raises on 401 and
+# /api/version returns 401 once auth is on - that read 'unhealthy' forever. Any
+# reply below 500 means the server is up, which is all a healthcheck should ask.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
-    CMD curl -f http://localhost:5883/api/version || exit 1
+    CMD python -c "import http.client as h; c=h.HTTPConnection('localhost',5883,timeout=5); c.request('GET','/api/version'); exit(0 if c.getresponse().status < 500 else 1)" || exit 1
 
 # Starts as root only to join the docker socket's group, then drops to
 # `scanner` for the application itself. See entrypoint.sh.

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - NET_ADMIN
       - NET_RAW
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5883/api/version"]
+      test: ["CMD", "python", "-c", "import http.client as h; c=h.HTTPConnection('localhost',5883,timeout=5); c.request('GET','/api/version'); exit(0 if c.getresponse().status < 500 else 1)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -34,7 +34,10 @@ if [ "$(id -u)" = "0" ]; then
         [ -d "$dir" ] && chown -R scanner:scanner "$dir" 2>/dev/null || true
     done
 
-    exec gosu scanner "$@"
+    # setpriv, not gosu: gosu is a Go binary whose stdlib carried 39 CVEs, and
+    # setpriv ships with util-linux in the base image. --init-groups picks up
+    # the docker-socket group joined just above, same as gosu did.
+    exec setpriv --reuid=scanner --regid=scanner --init-groups "$@"
 fi
 
 # Already unprivileged (user: override in compose, or a rootless runtime).

--- a/deploy/marketplaces/casaos/docker-compose.yml
+++ b/deploy/marketplaces/casaos/docker-compose.yml
@@ -42,7 +42,7 @@ services:
         reservations:
           memory: "256M"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5883/api/version"]
+      test: ["CMD", "python", "-c", "import http.client as h; c=h.HTTPConnection('localhost',5883,timeout=5); c.request('GET','/api/version'); exit(0 if c.getresponse().status < 500 else 1)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/deploy/marketplaces/coolify/mynes.yaml
+++ b/deploy/marketplaces/coolify/mynes.yaml
@@ -28,7 +28,7 @@ services:
       # br-* bridges. Remove it to keep the Docker API out of MyNeS.
       - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5883/api/version"]
+      test: ["CMD", "python", "-c", "import http.client as h; c=h.HTTPConnection('localhost',5883,timeout=5); c.request('GET','/api/version'); exit(0 if c.getresponse().status < 500 else 1)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/deploy/marketplaces/portainer/docker-compose.yml
+++ b/deploy/marketplaces/portainer/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       # br-* bridges. Remove it to keep the Docker API out of MyNeS.
       - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5883/api/version"]
+      test: ["CMD", "python", "-c", "import http.client as h; c=h.HTTPConnection('localhost',5883,timeout=5); c.request('GET','/api/version'); exit(0 if c.getresponse().status < 500 else 1)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/docker-deployment.md
+++ b/docs/docker-deployment.md
@@ -569,7 +569,7 @@ docker run --log-driver=json-file --log-opt max-size=10m --log-opt max-file=3
 
 ```bash
 # Set up health check alerts
-docker run -d --health-cmd="curl -f http://localhost:5883/api/version" \
+docker run -d --health-cmd="python -c \"import http.client as h; c=h.HTTPConnection('localhost',5883,timeout=5); c.request('GET','/api/version'); exit(0 if c.getresponse().status < 500 else 1)\"" \
            --health-interval=30s \
            --health-timeout=10s \
            --health-retries=3 \


### PR DESCRIPTION
Docker Scout reported **79** vulnerabilities on the published image. Building the same Dockerfile locally reports **118** — Hub reads its SBOM from the provenance attestation, which lists deb packages and misses the Go stdlib compiled into `gosu`. Those 39 hidden findings included 1 CRITICAL and 16 HIGH.

## What changed

| Removed | Findings | Replaced by |
|---|---|---|
| `gosu` | 39 (1C 16H 19M) | `setpriv` — util-linux, already in the base image |
| `perl-base` | 11 (2C 2H 2M 2L 3?) | nothing runs perl; nmap's NSE is Lua |
| `curl` + libcurl/openldap/krb5/gnutls | 15 | `python -c` in the HEALTHCHECK |
| `pip` / `setuptools` / `wheel` | 5 | uninstalled after the build |

**118 → 52. 3 CRITICAL + 18 HIGH → 0 + 0.** Everything left is MEDIUM or lower and unfixed upstream in Debian (glibc, tar, util-linux, coreutils); a periodic rebuild clears those, not a change here.

Upgrading pip instead of removing it makes things worse — the newer pip vendors `msgpack` and pulls `setuptools` forward, adding 2 HIGH.

## Healthcheck bug fixed on the way past

The rpifx container had a `FailingStreak` of **393**: `/api/version` answers 401 once auth is on and `curl -f` treats that as down. The check now uses `http.client` and accepts anything under 500 — the server being up is all a healthcheck should ask.

## Verification

- Raw ARP still works under `setpriv` + file capabilities: `CapEff 0x3000` (NET_RAW|NET_ADMIN) on PID 1, `last_arp_method = arp-raw` — not the ping-sweep fallback.
- Real LAN scan on rpifx (arm64, copy of live config + data): **73 devices, 66 typed, 44 aliased, 52 with vendor** vs 71/64/42/50 in the live snapshot.
- Container reports `healthy`, app runs as uid 1000.
- 109 tests pass.

## Cost

The image can no longer `apt-get install`. README documents this under "İmajda apt yok" — add tools to the Dockerfile and rebuild instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)