### PR TITLE
feat: make Bluetooth LE discovery work in the container image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to MyNeS (My Network Scanner) are documented here.
 Format loosely follows [Keep a Changelog](https://keepachangelog.com/1.1.0/);
 versioning follows [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Bluetooth LE discovery actually works in a container.** The README, the
+  add-on description and the marketplace listings have all promised "including
+  the Zigbee, Z-Wave, Matter and Bluetooth LE ones an IP scan cannot find" since
+  1.3.0, but `deploy/requirements-docker.txt` left `bleak` out on the grounds
+  that "containers have no BLE adapter". That is true of a bridged container and
+  false of the way MyNeS is actually deployed: `network_mode: host` on a box
+  whose `bluetoothd` is already running. bleak does not drive the radio on
+  Linux, it asks BlueZ over the D-Bus system bus — so the image needs no BlueZ
+  packages, no USB passthrough and no `privileged: true`, only the bus socket
+  mounted at run time. The image now ships `bleak`, and the manifests mount
+  `/run/dbus/system_bus_socket`. The app still runs as the unprivileged
+  `scanner` user; BlueZ's default D-Bus policy already allows it.
+
+### Fixed
+
+- **`ble: ok` while finding nothing.** `available()` only checked that `bleak`
+  imports, which says nothing about whether the bus is reachable. A container
+  without the socket therefore reported the backend as healthy with a count of
+  zero — identical to a scan that legitimately found no BLE devices — and the
+  underlying failure surfaced only as a logged `[Errno 2] No such file or
+  directory`. The backend now checks for the system bus up front and reports the
+  mount that is missing, so `/api/capabilities` and the Discovery page name the
+  cause. The check tests for a *socket* rather than mere existence, because
+  docker creates an empty directory at a bind mount whose source is absent,
+  which would otherwise look healthy and fail later.
+
 ## [1.4.0] — 2026-08-04
 
 Everything here came out of installing 1.3.0 from the CasaOS store onto a

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -21,6 +21,16 @@ services:
       # :ro would only break the mount without restricting the API anyway.
       # Drop this line if you would rather not expose the Docker API.
       - /var/run/docker.sock:/var/run/docker.sock
+      # Optional, Linux only. Turns on Bluetooth LE discovery - trackers,
+      # sensors, watches and BLE smart-home gear have no IP and cannot be
+      # scanned any other way. bleak reaches the host's BlueZ over the D-Bus
+      # system bus; no USB passthrough and no privileged: true involved, and
+      # the app still runs as the unprivileged `scanner` user.
+      # Not :ro - connecting to a unix socket needs write permission on it.
+      # Uncomment only if the host runs bluetoothd. If the path does not exist
+      # docker silently creates a directory there, and MyNeS will report the
+      # bus as unreachable on the Discovery page rather than guess.
+      # - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket
     environment:
       MYNES_PORT: 5883
       # Set in a .env file next to this compose file. Leave unset to auto-generate.

--- a/deploy/marketplaces/casaos/docker-compose.yml
+++ b/deploy/marketplaces/casaos/docker-compose.yml
@@ -37,6 +37,14 @@ services:
       - type: bind
         source: /var/run/docker.sock
         target: /var/run/docker.sock
+      # Bluetooth LE discovery. bleak reaches the host's BlueZ over the D-Bus
+      # system bus, so this needs no USB passthrough and no privileged: true,
+      # and the app still runs as the unprivileged `scanner` user. Harmless on a
+      # host with no bluetoothd - MyNeS reports the bus as unreachable on the
+      # Discovery page instead of failing the scan.
+      - type: bind
+        source: /run/dbus/system_bus_socket
+        target: /run/dbus/system_bus_socket
     deploy:
       resources:
         reservations:
@@ -99,6 +107,10 @@ services:
           description:
             en_US: Optional. Lets MyNeS name your containers and the docker networks behind the br-* bridges. Remove it to keep the Docker API out of MyNeS.
             tr_TR: İsteğe bağlı. MyNeS'in container'larınızı ve br-* köprülerinin arkasındaki docker ağlarını isimlendirmesini sağlar. Docker API'sini MyNeS'ten uzak tutmak için kaldırabilirsiniz.
+        - container: /run/dbus/system_bus_socket
+          description:
+            en_US: Optional. Enables Bluetooth LE discovery through the host's BlueZ - trackers, sensors, watches and BLE smart-home gear have no IP and cannot be found any other way. Remove it to disable BLE.
+            tr_TR: İsteğe bağlı. Ana makinenin BlueZ servisi üzerinden Bluetooth LE keşfini etkinleştirir - takip cihazları, sensörler, saatler ve BLE akıllı ev cihazlarının IP adresi yoktur ve başka türlü bulunamaz. BLE'yi devre dışı bırakmak için kaldırabilirsiniz.
 x-casaos:
   id: io.github.fxerkan.mynes
   version: "1.4.0"

--- a/deploy/marketplaces/coolify/mynes.yaml
+++ b/deploy/marketplaces/coolify/mynes.yaml
@@ -27,6 +27,11 @@ services:
       # Optional: names your containers and the docker networks behind the
       # br-* bridges. Remove it to keep the Docker API out of MyNeS.
       - /var/run/docker.sock:/var/run/docker.sock
+      # Bluetooth LE discovery: bleak reaches the host's BlueZ over the D-Bus
+      # system bus, so no USB passthrough and no privileged mode - the app still
+      # runs unprivileged. Harmless if the host has no bluetoothd: MyNeS reports
+      # the bus as unreachable instead of failing. Remove to disable BLE.
+      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket
     healthcheck:
       test: ["CMD", "python", "-c", "import http.client as h; c=h.HTTPConnection('localhost',5883,timeout=5); c.request('GET','/api/version'); exit(0 if c.getresponse().status < 500 else 1)"]
       interval: 30s

--- a/deploy/marketplaces/cosmos/cosmos-compose.json
+++ b/deploy/marketplaces/cosmos/cosmos-compose.json
@@ -62,6 +62,11 @@
           "type": "bind",
           "source": "/var/run/docker.sock",
           "target": "/var/run/docker.sock"
+        },
+        {
+          "type": "bind",
+          "source": "/run/dbus/system_bus_socket",
+          "target": "/run/dbus/system_bus_socket"
         }
       ],
       "labels": {

--- a/deploy/marketplaces/homeassistant-addon/mynes/config.yaml
+++ b/deploy/marketplaces/homeassistant-addon/mynes/config.yaml
@@ -15,6 +15,10 @@ startup: application
 boot: auto
 # ARP / mDNS / SSDP discovery only works from the host network namespace.
 host_network: true
+# Mounts the host's D-Bus system bus at /run/dbus, which is how bleak reaches
+# BlueZ for Bluetooth LE discovery. The supervisor option exists precisely for
+# this, so no USB passthrough and no `privileged: SYS_ADMIN` are needed.
+host_dbus: true
 privileged:
   - NET_ADMIN
   - NET_RAW

--- a/deploy/marketplaces/portainer/docker-compose.yml
+++ b/deploy/marketplaces/portainer/docker-compose.yml
@@ -25,6 +25,11 @@ services:
       # Optional: names your containers and the docker networks behind the
       # br-* bridges. Remove it to keep the Docker API out of MyNeS.
       - /var/run/docker.sock:/var/run/docker.sock
+      # Bluetooth LE discovery: bleak reaches the host's BlueZ over the D-Bus
+      # system bus, so no USB passthrough and no privileged mode - the app still
+      # runs unprivileged. Harmless if the host has no bluetoothd: MyNeS reports
+      # the bus as unreachable instead of failing. Remove to disable BLE.
+      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket
     healthcheck:
       test: ["CMD", "python", "-c", "import http.client as h; c=h.HTTPConnection('localhost',5883,timeout=5); c.request('GET','/api/version'); exit(0 if c.getresponse().status < 500 else 1)"]
       interval: 30s

--- a/deploy/marketplaces/runtipi/docker-compose.yml
+++ b/deploy/marketplaces/runtipi/docker-compose.yml
@@ -21,6 +21,11 @@ services:
       # Optional: names your containers and the docker networks behind the
       # br-* bridges. Remove it to keep the Docker API out of MyNeS.
       - /var/run/docker.sock:/var/run/docker.sock
+      # Bluetooth LE discovery: bleak reaches the host's BlueZ over the D-Bus
+      # system bus, so no USB passthrough and no privileged mode - the app still
+      # runs unprivileged. Harmless if the host has no bluetoothd: MyNeS reports
+      # the bus as unreachable instead of failing. Remove to disable BLE.
+      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket
     labels:
       traefik.enable: ${APP_EXPOSED}
       traefik.http.middlewares.mynes-web-redirect.redirectscheme.scheme: https

--- a/deploy/marketplaces/umbrel/docker-compose.yml
+++ b/deploy/marketplaces/umbrel/docker-compose.yml
@@ -20,3 +20,8 @@ services:
       # Optional: names your containers and the docker networks behind the
       # br-* bridges. Remove it to keep the Docker API out of MyNeS.
       - /var/run/docker.sock:/var/run/docker.sock
+      # Bluetooth LE discovery: bleak reaches the host's BlueZ over the D-Bus
+      # system bus, so no USB passthrough and no privileged mode - the app still
+      # runs unprivileged. Harmless if the host has no bluetoothd: MyNeS reports
+      # the bus as unreachable instead of failing. Remove to disable BLE.
+      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket

--- a/deploy/requirements-docker.txt
+++ b/deploy/requirements-docker.txt
@@ -1,5 +1,4 @@
 # Container image deps: core + discovery + analysis.
-# Bluetooth (bleak) is omitted - containers have no BLE adapter.
 flask>=3.0
 python-nmap>=0.7
 requests>=2.31
@@ -16,3 +15,11 @@ websocket-client>=1.7
 # Web push: the server half of the alert notifications. Without it the whole
 # feature reports "unsupported" no matter what the browser can do.
 pywebpush>=1.14
+# BLE. This was left out on the assumption that a container has no adapter,
+# which is wrong for the way MyNeS is actually deployed: network_mode: host on a
+# box whose BlueZ is already running. bleak asks BlueZ over D-Bus rather than
+# driving the radio, so the image needs no BlueZ packages and no device
+# passthrough - only the bus socket mounted at run time. Its Linux backend
+# (dbus-fast) ships prebuilt wheels for amd64 and aarch64, so this does not
+# put a compiler in the build.
+bleak>=0.22

--- a/docs/DOCKER_README.md
+++ b/docs/DOCKER_README.md
@@ -38,6 +38,8 @@ services:
     volumes:
       - ./data:/app/data
       - ./config:/app/config
+      # Optional, Linux only — turns on Bluetooth LE discovery.
+      - /run/dbus/system_bus_socket:/run/dbus/system_bus_socket
     environment:
       MYNES_PORT: 5883
       MYNES_PASSWORD: ""        # auto-generated on first start if empty
@@ -116,6 +118,7 @@ namespace — from a bridge network it can only see the bridge, not the LAN.
 | **Far fewer devices than expected** | Open `GET /api/capabilities` — it lists exactly which protocol backends and privileges are missing, and why. That is the first thing to read, always. |
 | **Running Docker Desktop (macOS/Windows)** | Host networking is not fully supported there. Drop `network_mode: host`, use `ports: ["5883:5883"]`, and accept reduced discovery. |
 | **No Zigbee / Z-Wave devices** | Set `MYNES_MQTT_HOST` (plus username/password) to your broker. Those devices have no IP; MQTT is the only way to see them. |
+| **No Bluetooth LE devices** | Mount `/run/dbus/system_bus_socket` into the container and make sure `bluetoothd` is running on the host. MyNeS scans BLE *through* the host's BlueZ, so it needs no USB passthrough and no privileged mode — but without that socket it cannot reach the adapter, and `/api/capabilities` will say so. Linux only: Docker Desktop VMs have no Bluetooth stack to borrow. |
 | **Port 5883 already taken** | Set `MYNES_PORT` to something else. |
 | **Is it alive?** | The image ships a health check against `GET /api/version`. |
 

--- a/mynes/discovery/bluetooth.py
+++ b/mynes/discovery/bluetooth.py
@@ -7,11 +7,25 @@ on the IP network; the merger treats them as standalone entries.
 
 Requires: pip install "mynes[bluetooth]" and OS Bluetooth permission
 (macOS: Terminal needs Bluetooth access in System Settings > Privacy).
+
+In a container this also needs the host's D-Bus system bus socket bind-mounted
+in - see `available()` and deploy/docker-compose.yml. It does NOT need a USB
+dongle passed through: on Linux bleak never touches the adapter directly, it
+asks BlueZ over D-Bus, and BlueZ runs on the host.
 """
 
 from __future__ import annotations
 
+import os
+import stat
+import sys
+
 from mynes.discovery.base import DiscoveredDevice, DiscoveryBackend
+
+# Where D-Bus puts the system bus socket on every mainstream Linux. bleak talks
+# to BlueZ through it; without it the adapter is unreachable no matter how
+# healthy `hciconfig` looks on the host.
+DBUS_SYSTEM_SOCKET = "/run/dbus/system_bus_socket"
 
 # Bluetooth SIG company identifiers seen most often in a home.
 COMPANY_IDS = {
@@ -45,9 +59,66 @@ SERVICE_HINTS = {
 }
 
 
+def _is_socket(path: str) -> bool:
+    """Socket, not merely present.
+
+    Deliberately not os.path.exists: docker creates an empty *directory* at the
+    source of a bind mount that does not exist on the host, so a typo'd or
+    Docker-Desktop-shaped mount leaves a plausible-looking path that can never
+    be connected to. Checking the type turns that into a clear reason.
+    """
+    try:
+        return stat.S_ISSOCK(os.stat(path).st_mode)
+    except OSError:
+        return False
+
+
+def _dbus_system_bus_reachable() -> bool:
+    """Is there a system bus socket to talk to?
+
+    DBUS_SYSTEM_BUS_ADDRESS wins when set, since that is how an operator moves
+    the bus. Its value is a semicolon-separated list of addresses; we can only
+    verify the unix ones, so anything else (tcp:, autolaunch:) is taken on faith
+    rather than reported as broken.
+    """
+    address = os.environ.get("DBUS_SYSTEM_BUS_ADDRESS")
+    if not address:
+        return _is_socket(DBUS_SYSTEM_SOCKET)
+
+    checkable = False
+    for candidate in address.split(";"):
+        for part in candidate.split(","):
+            if part.startswith("unix:path="):
+                checkable = True
+                if _is_socket(part.split("=", 1)[1]):
+                    return True
+    return not checkable
+
+
 class BluetoothBackend(DiscoveryBackend):
     name = "ble"
     requires = ("bleak",)
+
+    def available(self) -> tuple[bool, str]:
+        """(usable?, reason), with the reason an operator can act on.
+
+        bleak imports fine without a reachable bus and only fails once a scan is
+        already running, where the error surfaces as a bare
+        "[Errno 2] No such file or directory". That reported `ble: ok, count 0`
+        - indistinguishable from "scanned, found nothing" - so the missing mount
+        is caught here instead, where /api/capabilities can say so.
+        """
+        ok, reason = super().available()
+        if not ok:
+            return ok, reason
+        # Only Linux routes through D-Bus. macOS uses CoreBluetooth and Windows
+        # WinRT, neither of which has a socket to look for.
+        if sys.platform.startswith("linux") and not _dbus_system_bus_reachable():
+            return False, (
+                f"no D-Bus system bus - bind-mount {DBUS_SYSTEM_SOCKET} "
+                "into the container (host BlueZ is what actually scans)"
+            )
+        return True, "ok"
 
     def discover(self, timeout: float = 8.0) -> list[DiscoveredDevice]:
         import asyncio

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -5,7 +5,9 @@ and threw them away. The merge is what makes the results persist, so it is the
 part worth pinning down.
 """
 
-from mynes.discovery import dhcp, ssdp
+import pytest
+
+from mynes.discovery import bluetooth, dhcp, ssdp
 from mynes.web.api import _apply_discovery
 
 
@@ -58,6 +60,88 @@ def test_sweep_fills_gaps_but_never_overwrites():
     assert router["discovery"]["attributes"]["ssdp"]["descriptions"]["u"]["serialNumber"] == "S1"
     assert tv["hostname"] == "my-tv"  # existing name survives
     assert tv["discovery"]["sources"] == ["mdns"]
+
+
+# --- BLE availability ------------------------------------------------------
+#
+# The container image ships bleak, so `import bleak` succeeding no longer means
+# BLE can work: on Linux it also needs the host's D-Bus system bus mounted in.
+# Without this check the backend reported "ok" and returned zero devices, which
+# reads exactly like a scan that found nothing.
+
+@pytest.fixture
+def _no_dbus_env(monkeypatch):
+    monkeypatch.delenv("DBUS_SYSTEM_BUS_ADDRESS", raising=False)
+    monkeypatch.setattr(bluetooth.sys, "platform", "linux")
+
+
+def test_ble_unavailable_without_a_system_bus(monkeypatch, _no_dbus_env):
+    monkeypatch.setattr(bluetooth, "_is_socket", lambda _p: False)
+    monkeypatch.setattr(bluetooth.BluetoothBackend, "requires", ())
+
+    ok, reason = bluetooth.BluetoothBackend().available()
+    assert ok is False
+    assert "/run/dbus/system_bus_socket" in reason
+
+
+def test_ble_available_when_the_bus_is_mounted(monkeypatch, _no_dbus_env):
+    monkeypatch.setattr(bluetooth, "_is_socket",
+                        lambda p: p == bluetooth.DBUS_SYSTEM_SOCKET)
+    monkeypatch.setattr(bluetooth.BluetoothBackend, "requires", ())
+
+    assert bluetooth.BluetoothBackend().available() == (True, "ok")
+
+
+def test_a_directory_is_not_a_bus(tmp_path, monkeypatch, _no_dbus_env):
+    """docker creates a *directory* when a bind mount's source is missing.
+
+    os.path.exists is true for it, so the old shape of this check would have
+    called a typo'd mount healthy and failed later with "No such file".
+    """
+    monkeypatch.setattr(bluetooth, "DBUS_SYSTEM_SOCKET", str(tmp_path))
+    monkeypatch.setattr(bluetooth.BluetoothBackend, "requires", ())
+
+    assert bluetooth.BluetoothBackend().available()[0] is False
+
+
+def test_dbus_address_env_overrides_the_default_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(bluetooth.sys, "platform", "linux")
+    monkeypatch.setenv("DBUS_SYSTEM_BUS_ADDRESS",
+                       f"unix:path={tmp_path / 'bus'},guid=abc")
+    monkeypatch.setattr(bluetooth, "_is_socket",
+                        lambda p: p == str(tmp_path / "bus"))
+    monkeypatch.setattr(bluetooth.BluetoothBackend, "requires", ())
+
+    assert bluetooth.BluetoothBackend().available() == (True, "ok")
+
+
+def test_non_unix_dbus_address_is_taken_on_faith(monkeypatch):
+    """A tcp: bus cannot be stat'd - refusing to scan would be a false negative."""
+    monkeypatch.setattr(bluetooth.sys, "platform", "linux")
+    monkeypatch.setenv("DBUS_SYSTEM_BUS_ADDRESS", "tcp:host=10.0.0.2,port=1234")
+    monkeypatch.setattr(bluetooth, "_is_socket", lambda _p: False)
+    monkeypatch.setattr(bluetooth.BluetoothBackend, "requires", ())
+
+    assert bluetooth.BluetoothBackend().available() == (True, "ok")
+
+
+def test_non_linux_never_looks_for_a_socket(monkeypatch):
+    """macOS goes through CoreBluetooth; there is no bus to find."""
+    monkeypatch.setattr(bluetooth.sys, "platform", "darwin")
+    monkeypatch.setattr(bluetooth, "_is_socket", lambda _p: False)
+    monkeypatch.setattr(bluetooth.BluetoothBackend, "requires", ())
+
+    assert bluetooth.BluetoothBackend().available() == (True, "ok")
+
+
+def test_missing_bleak_still_wins_over_the_bus_check(monkeypatch):
+    """A clear "install bleak" must not be masked by a D-Bus complaint."""
+    monkeypatch.setattr(bluetooth.sys, "platform", "linux")
+    monkeypatch.setattr(bluetooth.BluetoothBackend, "requires", ("not_a_real_module",))
+
+    ok, reason = bluetooth.BluetoothBackend().available()
+    assert ok is False
+    assert "not_a_real_module" in reason
 
 
 def test_applying_twice_is_a_no_op():


### PR DESCRIPTION
## What

BLE discovery has been advertised since 1.3.0 — the README, the add-on description and every
marketplace listing promise *"including the Zigbee, Z-Wave, Matter and Bluetooth LE ones an IP
scan cannot find"* — but `deploy/requirements-docker.txt` deliberately left `bleak` out:

```
# Bluetooth (bleak) is omitted - containers have no BLE adapter.
```

That is true of a bridged container and false of the way MyNeS is actually deployed:
`network_mode: host` on a box whose `bluetoothd` is already running. On Linux bleak never drives
the radio — it asks BlueZ over the D-Bus system bus. So the image needs **no BlueZ packages, no USB
passthrough and no `privileged: true`**, only the bus socket mounted at run time. The app still runs
as the unprivileged `scanner` user; BlueZ's default D-Bus policy (`<policy context="default">`)
already permits it.

Notably this needs no change to `deploy/Dockerfile` — `pip install` already runs before the
`setcap` line, so the capability-carrying interpreter is never in the way of the install.

## Also fixes the silent half

`available()` only checked that `bleak` imports, which says nothing about whether the bus is
reachable. A container without the socket therefore reported:

```
ble: {"count": 0, "status": "ok", "detail": "ok"}
```

— indistinguishable from a scan that legitimately found nothing — while the real failure appeared
only as a logged `[Errno 2] No such file or directory`. The bus is now checked up front and the
missing mount named, so `/api/capabilities` (which `docs/DOCKER_README.md` calls "the first thing
to read, always") can explain it:

```
ble: {"count": 0, "status": "skipped",
      "detail": "no D-Bus system bus - bind-mount /run/dbus/system_bus_socket into the container
                 (host BlueZ is what actually scans)"}
```

The check tests for a **socket** rather than mere existence, because docker creates an empty
*directory* at a bind mount whose source is absent — `os.path.exists` would call that healthy and
fail later anyway.

## Manifests

Mount added to CasaOS, Portainer, Umbrel, Runtipi, Coolify and Cosmos, plus `host_dbus: true` for
the Home Assistant add-on (the supervisor option that exists for exactly this).

It is **active** in those, since they are Linux-only self-hosted targets and a host without
`bluetoothd` now degrades to a clear message rather than a failure. It is left **commented** in
`deploy/docker-compose.yml`, the one path that also gets used on Docker Desktop, whose VM has no
Bluetooth stack to borrow.

## Verification

Run on a Raspberry Pi 4 (aarch64, BlueZ 5.x, `hci0` up), against an image built from this branch
with the real `deploy/Dockerfile`, dropped to the `scanner` user via `setpriv`:

| Case | Result |
| --- | --- |
| With the mount | `available: (True, 'ok')`, **3 BLE devices** found |
| Without the mount | `(False, 'no D-Bus system bus - bind-mount …')` |
| Mount pointed at a directory | `(False, 'no D-Bus system bus - bind-mount …')` |
| `getcap` after build | `cap_net_admin,cap_net_raw=eip` — raw ARP unaffected |

Full suite: **107 passed, 1 skipped**. `ruff check` clean. All 8 edited YAML/JSON manifests parse.
`dbus-fast` ships prebuilt amd64 + aarch64 wheels, so no compiler enters the build.

## Tests

7 new cases in `tests/test_discovery.py`: missing bus, directory-not-socket, `DBUS_SYSTEM_BUS_ADDRESS`
override, non-unix (`tcp:`) addresses taken on faith, non-Linux platforms, and missing-`bleak`
taking precedence over the D-Bus complaint.

## Note for a separate issue

Because `python3.12` carries `cap_net_admin=eip`, the image cannot exec Python **at all** without
`cap_add: NET_ADMIN` — it fails with `Operation not permitted` rather than degrading. Every shipped
manifest includes the cap so nobody hits it today, but a user who drops it for hardening gets a
container that will not start with a confusing error. Pre-existing and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L5eorpnSRz5mJsJR41c6P
